### PR TITLE
feat: add hex release github action workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  CACHE_VERSION: v1
+  ELIXIR_VERSION: "1.13"
+  OTP_VERSION: "25"
+
+jobs:
+  Hex:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - id: beam
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+      - id: cache
+        uses: actions/cache@v3
+        with:
+          key: |
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-release-{{ hashFiles('mix.lock') }}-${{ github.ref }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-release-{{ hashFiles('mix.lock') }}-${{ format('refs/heads/{0}', github.event.repository.default_branch) }}
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-release-
+            ${{ env.CACHE_VERSION }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
+          path: |
+            _build
+            deps
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: mix deps.get
+      - run: mix compile --docs
+      - run: mix hex.publish --yes
+        with:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Novu
 
-**TODO: Add description**
+An Elixir SDK for [Novu](https://novu.co/).
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `novu` to your list of dependencies in `mix.exs`:
+Novu is available on Hex.pm. Just add this line to your `mix.exs` file:
 
 ```elixir
 def deps do
@@ -15,7 +14,4 @@ def deps do
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/novu>.
-
+Documentation is available on [HexDocs](https://hexdocs.pm/novu/readme.html).


### PR DESCRIPTION
~Currently waiting for someone from novu to add a secret key~ done, but this will build and release the package to hex.pm.

Version bumping and changelog generating are still manual until we get an idea for that.