### PR TITLE
feat: add notification groups module

### DIFF
--- a/lib/novu/notification_groups.ex
+++ b/lib/novu/notification_groups.ex
@@ -1,0 +1,27 @@
+defmodule Novu.NotificationGroups do
+  @moduledoc """
+  Provide access to the Novu Notification Groups API
+  """
+
+  alias Novu.Http
+
+  @doc """
+  Creates a notification group
+
+  [API Documentation](https://docs.novu.co/api/create-notification-group/)
+  """
+  @spec create_notification_group(name :: String.t()) :: Http.response()
+  def create_notification_group(name) do
+    Http.post("/v1/notification-groups", %{name: name})
+  end
+
+  @doc """
+  Retrieves a list of notifications groups
+
+  [API Documentation](https://docs.novu.co/api/get-notification-groups/)
+  """
+  @spec get_notification_groups :: Http.response()
+  def get_notification_groups do
+    Http.get("/v1/notification-groups")
+  end
+end

--- a/test/novu/notification_groups_test.exs
+++ b/test/novu/notification_groups_test.exs
@@ -1,0 +1,47 @@
+defmodule Novu.NotificationGroupsTest do
+  use ExUnit.Case, async: true
+
+  import Novu.ApiTestHelpers
+
+  alias Novu.NotificationGroups
+
+  @test_api_key "test-api-key"
+
+  setup do
+    bypass = Bypass.open()
+
+    current_domain = Application.get_env(:novu, :domain)
+
+    Application.put_env(:novu, :domain, "http://localhost:#{bypass.port}")
+    Application.put_env(:novu, :api_key, @test_api_key)
+
+    on_exit(fn ->
+      Application.put_env(:novu, :domain, current_domain)
+    end)
+
+    {:ok, bypass: bypass}
+  end
+
+  describe "create_notification_group/1" do
+    test "creates a POST to /v1/notification-groups", %{bypass: bypass} do
+      notification_group_name = "Test"
+
+      Bypass.expect(bypass, "POST", "/v1/notification-groups", fn conn ->
+        assert %{"name" => ^notification_group_name} = read_json_body(conn)
+        novu_response(conn, 201, %{data: %{name: notification_group_name}})
+      end)
+
+      assert {:ok, _body} = NotificationGroups.create_notification_group(notification_group_name)
+    end
+  end
+
+  describe "get_notification_groups/0" do
+    test "creates a GET to /v1/notification-groups", %{bypass: bypass} do
+      Bypass.expect(bypass, "GET", "/v1/notification-groups", fn conn ->
+        novu_response(conn, 201, %{data: []})
+      end)
+
+      assert {:ok, _body} = NotificationGroups.get_notification_groups()
+    end
+  end
+end


### PR DESCRIPTION
Adds `Novu.NotificationGroups` module with the following functions:
- `create_notification_group/1`
- `get_notification_groups/0`