### PR TITLE
fix: update user agent to match novu standards

### DIFF
--- a/lib/novu/http.ex
+++ b/lib/novu/http.ex
@@ -4,9 +4,10 @@ defmodule Novu.Http do
   will include base headers, authentication, response parsing, and error
   handling.
   """
+
   require Logger
 
-  @user_agent "novuhq-elixir/ " <> Mix.Project.config()[:version] <> " (+https://github.com/novuhq/elixir)"
+  @user_agent "novu/elixir@ " <> Mix.Project.config()[:version]
 
   @type response() :: {:ok, map()} | {:error, list() | :timeout | any()}
 


### PR DESCRIPTION
Fixes https://github.com/novuhq/novu-elixir/issues/37 by setting the user agent to how Novu expects. This does remove the HTTP url which is annoying but I'd rather follow the Novu standards here.